### PR TITLE
fixed inconsistency in settings args in plotting

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -13,7 +13,9 @@ from utils.git_tools import git_pull, git_push
 
 git_pull() ## pull from github to get latest version of code
 
-models_dicts, settings_dict = get_settings()
+settings_file = './settings.json'
+
+models_dicts, settings_dict = get_settings(settings_file)
     
 lc_path = settings_dict['candidate_directory']
 fit_path = settings_dict['fit_directory']
@@ -45,7 +47,7 @@ while True:
         
 ## plot lightcurves
 for object in new_objects:
-    plot_lightcurves(object, models_dicts, settings_dict)
+    plot_lightcurves(object, settings_file)
 time.sleep(60) ## wait 1 minute to make sure all plots have been saved (may be unnecessary)
 
 commit_message = 'Added fits for objects: {}'.format(', '.join(new_objects))

--- a/utils/files.py
+++ b/utils/files.py
@@ -129,6 +129,13 @@ def check_fit_completion(objects, models, settings, elapsed_time):
         objects (list): path to directories of objects
         models (dict): dictionary of models and their settings
         settings (dict): settings dictionary from settings.json
+        elapsed_time (float): time elapsed since start of fit in hours
+        
+    Returns:
+        boolean: True if all fits are complete or hit timeout, False otherwise
+    
+    To-Do:
+        - add an argument for the number of anticipated fits to account for any failures in job creation and/or submission (would be a try/except in the scanner.py file)
     '''
     timeout = settings['timeout'] ## timeout in hours (default of 8 hours)
     object_completed_jobs = {object:[] for object in objects} ## dictionary of objects and their completed jobs

--- a/utils/fitting.py
+++ b/utils/fitting.py
@@ -53,7 +53,7 @@ def generate_job(object, model, settings):
     
     Args:
         object (str): path to object lightcurve
-        model (dict): dictionary of model, including job settings from settings.json
+        model (dict): dictionary of model, including job settings from settings.json (the value corresponding to the model key from the models dictionary in settings.json)
         settings (dict): dictionary of settings from settings.json
         
     Returns:

--- a/utils/plotting.py
+++ b/utils/plotting.py
@@ -24,7 +24,7 @@ def combine_dataframes(data_file, settings_file, sample_times=np.linspace(0.01, 
     
     Args:
         data_file (str): path to dat file containing lightcurve data
-        settings_file (dict): dictionary of settings for nmma job (see fitting.generate_job for better idea of intended structure)
+        settings_file (str): path to settings file
         model (dict): dictionary of model, including job settings from settings.json (see fitting.generate_job for better idea of intended structure)
         sample_times (np.array): array of times to sample the lightcurve at (default is 100 samples from 0.01 to 7 days)
         
@@ -53,7 +53,7 @@ def plot_lightcurves(data_file, settings_file, sample_times=np.linspace(0.01,7,1
     
     Args:
         data_file (str): path to dat file containing lightcurve data
-        settings_file (dict): dictionary of settings for nmma job (see fitting.generate_job for better idea of intended structure)
+        settings_file (str): path to settings file
         sample_times (np.array): array of times to sample the lightcurve at (default is 100 samples from 0.01 to 7 days)
         
     Returns:


### PR DESCRIPTION
plot_lightcurves was being passed the settings as a dict when it should have been passed the string that corresponded to the path to the settings_file. May be good to have greater consistency in which functions require the settings_file as a string and those that want the settings and model dicts.

In the case of something like fitting.generate_job(), the settings and model dicts are passed separately because the model_dict in this instance is one of the nested dictionary items in the overall models key in settings.json that corresponds to a given model. Could have discussion about whether it's better to have these functions execute on a model by model basis or if they should just get all the models and then generate/submit jobs for all models for a given object.